### PR TITLE
Fix/anvil sandbox startup

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-anvil --steps-tracing --auto-impersonate --host 0.0.0.0 --fork-url "${PROVIDER_URL}" --fork-block-number 29007455 &
+anvil --steps-tracing --auto-impersonate --host 0.0.0.0 --fork-url "${PROVIDER_URL}" --fork-block-number 48394000 &
 ANVIL_PID=$!
 
 until cast block-number --rpc-url http://localhost:8545 >/dev/null 2>&1; do sleep 1; done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 anvil --steps-tracing --auto-impersonate --host 0.0.0.0 --fork-url "${PROVIDER_URL}" --fork-block-number 29007455 &
 ANVIL_PID=$!
 
-sleep 3
+until cast block-number --rpc-url http://localhost:8545 >/dev/null 2>&1; do sleep 1; done
 
 # Cheating - grant Alpha role
 cast send 0x3033C274D3Ccc8d12B4Ea567F6F94849507c37aE "grantRole(uint64,address,uint32)" 200 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 0 --rpc-url http://localhost:8545 --from 0xF6a9bd8F6DC537675D499Ac1CA14f2c55d8b5569 --unlocked


### PR DESCRIPTION
Two fixes for the compose sandbox failing to grant ALPHA_ROLE on startup:

- wait for anvil RPC readiness instead of a fixed `sleep 3` — forking over
  a remote RPC routinely takes longer than 3 s, so the grant fired before
  anvil was listening;
- bump the pinned fork block (29007455 → 48394000) — free-tier RPCs have
  pruned state that old ("error code 4444: pruned history unavailable").
  Any pinned block ages out eventually; this one (2026-07-09) will need
  the same refresh in the future.

Symptom in both cases: the bot loops on revert 0x068ca9d8
(`AccessManagedUnauthorized`) because the alpha wallet never got the role.