### PR TITLE
[fix] gate the sandbox bot on ALPHA_ROLE being granted

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The project includes Docker configuration for easy deployment:
    - An anvil instance for local blockchain simulation
    - The alpha bot container connected to the anvil service
 
+   The bot starts only after anvil reports healthy, which means the fork is up and the
+   sandbox alpha wallet has been granted `ALPHA_ROLE`. If anvil never becomes healthy
+   (`docker compose ps`), the role grant in `docker-entrypoint.sh` failed; check `docker compose logs anvil`.
+
 
 ### Customizing the Bot
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
     environment:
       - PROVIDER_URL=http://anvil:8545/
     depends_on:
-      - anvil
+      anvil:
+        # Start the bot only once the alpha wallet holds ALPHA_ROLE, otherwise
+        # its immediate first cycle reverts with AccessManagedUnauthorized
+        condition: service_healthy
 
   anvil:
     container_name: anvil
@@ -22,3 +25,17 @@ services:
       - .env
     ports:
       - "8545:8545"
+    healthcheck:
+      # Healthy when the entrypoint's grantRole has been mined: ALPHA_ROLE (200)
+      # for anvil account #0 on the vault's AccessManager
+      test:
+        - CMD-SHELL
+        - >-
+          cast call 0x3033C274D3Ccc8d12B4Ea567F6F94849507c37aE
+          'hasRole(uint64,address)(bool,uint32)'
+          200 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+          --rpc-url http://localhost:8545 | grep -q true
+      interval: 2s
+      timeout: 10s
+      retries: 60
+      start_period: 30s


### PR DESCRIPTION
## Summary

Fix the compose sandbox's first-cycle failure. The bot runs `do_fusion()` immediately on startup while `docker-entrypoint.sh` grants `ALPHA_ROLE` a few seconds later, so cycle one always reverted with `AccessManagedUnauthorized` and only the retry a minute later succeeded.

## Change

- `docker-compose.yml`: anvil gets a healthcheck that passes only once the sandbox alpha wallet (anvil account #0) holds `ALPHA_ROLE` on the vault's AccessManager, via `cast call hasRole`. The bot uses `depends_on: anvil: condition: service_healthy`, so it starts only after the grant is mined
- README / sandbox notes: what "anvil never becomes healthy" means (the grant failed, see `docker compose logs anvil`)

The entrypoint is untouched; #5 (readiness wait before the grant, newer fork block) is independent and composes with this: #5 makes the grant reliable, this makes the bot wait for it.

## Verification

Run under podman-compose 1.5.0 (`condition: service_healthy` is supported there and in docker compose v2):

- `docker compose up -d` blocks until anvil is healthy, then starts the bot
- the bot's first cycle mines the Aave V3 supply on the first attempt, no `AccessManagedUnauthorized`
- a failed grant now shows up as an unhealthy anvil and a bot that never starts, instead of a bot looping on reverts
