### PR TITLE
[chore] drop CI inputs and secrets no workflow step consumes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,8 +16,6 @@ jobs:
     needs: notify
     uses: ./.github/workflows/python-build.yml
     secrets:
-      ETHEREUM_PROVIDER_URL: ${{ secrets.ETHEREUM_PROVIDER_URL }}
-      ARBITRUM_PROVIDER_URL: ${{ secrets.ARBITRUM_PROVIDER_URL }}
       BASE_PROVIDER_URL: ${{ secrets.BASE_PROVIDER_URL }}
 
   report:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     needs: notify
     uses: ./.github/workflows/python-build.yml
     secrets:
-      ETHEREUM_PROVIDER_URL: ${{ secrets.ETHEREUM_PROVIDER_URL }}
-      ARBITRUM_PROVIDER_URL: ${{ secrets.ARBITRUM_PROVIDER_URL }}
       BASE_PROVIDER_URL: ${{ secrets.BASE_PROVIDER_URL }}
 
   report:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -4,11 +4,7 @@ on:
   workflow_call:
 
     secrets:
-      ARBITRUM_PROVIDER_URL:
-        required: true
       BASE_PROVIDER_URL:
-        required: true
-      ETHEREUM_PROVIDER_URL:
         required: true
 
     inputs:
@@ -34,11 +30,6 @@ on:
         required: false
       static-code-analysis-enabled:
         description: "Enable static code analysis"
-        type: boolean
-        default: true
-        required: false
-      build-enabled:
-        description: "Enable package build"
         type: boolean
         default: true
         required: false


### PR DESCRIPTION
## Summary

Follow-up from the agent-readiness audit after #9. Everything else scored clean; this was the one remaining finding.

`python-build.yml` declared a `build-enabled` input that no step consumed (there is no build step and no build backend in `pyproject.toml`), and required `ARBITRUM_PROVIDER_URL` and `ETHEREUM_PROVIDER_URL` secrets that nothing reads. Only `BASE_PROVIDER_URL` feeds `PROVIDER_URL` for the tests.

- Remove the `build-enabled` input and the two unused required secrets from `python-build.yml`
- Stop passing those two secrets from `ci.yml` and `cd.yml`

Deletion-only, 13 lines. The format check, lint, and test steps and their `*-enabled` inputs are untouched.

## Verification

Run locally on this tree:

```
uv sync --locked            ok
uv lock --check             ok
uv run ruff check .         All checks passed!
uv run ruff format --check  9 files already formatted
uv run pytest -v -s         1 passed (eth_simulateV1 at block 29007455)
```

All five workflow files still parse as YAML. `actionlint` is not installed locally, so that was not run; CI on this PR exercises the changed workflow directly.
